### PR TITLE
Make license detectable by GitHub

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,17 +1,16 @@
 ## ISC License
 
-Copyright (C) 2015 Waldir Pimenta
-and [contributors](https://github.com/browserpad/browserpad/contributors)
+Copyright (C) 2015 Waldir Pimenta and [contributors](https://github.com/browserpad/browserpad/contributors)
 
 Permission to use, copy, modify, and/or distribute this software
 for any purpose with or without fee is hereby granted,
 provided that the above copyright notice and this permission notice
 appear in all copies.
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS
-DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE
+THE SOFTWARE IS PROVIDED "AS IS"
+AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE
 INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE
+IN NO EVENT SHALL THE AUTHOR BE LIABLE
 FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
 OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
 WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,


### PR DESCRIPTION
Tested with `licensee detect LICENSE.md` (<https://github.com/licensee/licensee> is what GitHub uses to detect repository licenses).