### PR TITLE
change selector to fix empty text file downloads

### DIFF
--- a/script.js
+++ b/script.js
@@ -38,7 +38,7 @@ function updateCount(item, value) {
 // save as file
 document.querySelector('#save a').onclick = function () {
     this.download = (filenameBox.value || 'browserpad.txt').replace(/^([^.]*)$/, "$1.txt");
-    this.href = URL.createObjectURL(new Blob([document.querySelector('textarea').value], { type: 'text/plain' }));
+    this.href = URL.createObjectURL(new Blob([document.querySelector('#textbox').value], { type: 'text/plain' }));
 };
 
 // open file


### PR DESCRIPTION
BrowserPad's save file function uses an incorrect querySelector to load the user's note text into a blob which then creates an empty blob for downloading. As a result, a user of BrowserPad.org will mistakenly believe that they have saved their notes because they see a new text file in their filesystem as expected, but that text file is empty. **The user could lose all notes** and not know until much later when they try to read their notes from the empty saved file.

This PR fixes the empty saved file (Issue #61) without making any additional changes. If @waldyrious prefers not split the file into three files as proposed by @SenadAlagic then this PR may be a happy middle ground because this PR fixes the empty save issue but preserves the single file simplicity.