### PR TITLE
added an svg "i" icon instead of the github one

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -29,16 +29,10 @@
         <input id="filename" placeholder="browserpad.txt" />
         <a href="#">save</a>
       </span> │
-        <a href="https://github.com/Browserpad/browserpad" title="source code on github">
-        <svg id="github-logo" width="20" height="20" viewBox="0 0 500 500"
-             xmlns="http://www.w3.org/2000/svg" version="1.1">
-          <path d="M 250, 0 c -138, 0 -250, 112 -250, 250, 0, 112, 73.3, 206, 174, 238, 10, 1, 14 -6, 14 -12
-                   v -43 c -70, 16 -84 -33 -84 -33 -11.8 -29 -28.1 -37 -28.1 -37 -22.8 -15, 1.7 -15, 1.7 -15,
-                   25.4, 2, 38.4, 26, 38.4, 26, 22, 38, 58, 27, 73, 21, 2 -16, 8 -28, 15 -34 -55 -6 -114 -28
-                   -114 -124, 0 -27, 9.5 -49, 25.5 -67 -2 -6 -11 -32, 3 -66, 0, 0, 21 -6.8, 68, 26, 20 -6, 42
-                   -9, 63 -9 s 43, 3, 63, 9 c 47 -32.9, 68 -26, 68 -26, 14, 34, 5, 60, 3, 66, 16, 18, 26, 40,
-                   26, 67, 0, 96 -59, 117 -114, 123, 8, 8, 16, 23, 16, 47 v 68 c 0, 7, 5, 14, 17, 12, 99 -33,
-                   171 -127, 171 -237, 0 -138 -112 -250 -250 -250 z" fill="#333333" />
+      <a href="https://github.com/Browserpad/browserpad" title="source code on github">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="18" height="18">
+          <circle cx="50" cy="50" r="50" fill="#333"/>
+          <text fill="white" font-family="serif" font-weight="bold" font-size="90" x="50" y="50" text-anchor="middle" dominant-baseline="central">i</text>
         </svg>
       </a>
     </span>

--- a/index.xhtml
+++ b/index.xhtml
@@ -32,12 +32,13 @@
       <a href="#" title="About Browserpad" id="about-icon">ⓘ</a>
     </span>
   </nav>
-  <div id="about">
+  <dialog id="about">
     <h2>Browserpad</h2>
     <p>As the name indicates, Browserpad is a notepad in the browser.</p>
     <p>It is a plain text editor built entirely with HTML, CSS and JavaScript.</p>
-    <p>(<a href="https://github.com/Browserpad/browserpad">source code available on github</a>)</p>
-  </div>
+    <p>The source code is <a href="https://github.com/Browserpad/browserpad">available on GitHub</a>.</p>
+    <form method="dialog"><button>close</button></form>
+  </dialog>
   <script src="script.js"></script>
 </body>
 </html>

--- a/index.xhtml
+++ b/index.xhtml
@@ -29,12 +29,7 @@
         <input id="filename" placeholder="browserpad.txt" />
         <a href="#">save</a>
       </span> │
-      <a href="https://github.com/Browserpad/browserpad" title="source code on github">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="18" height="18">
-          <circle cx="50" cy="50" r="50" fill="#333"/>
-          <text fill="white" font-family="serif" font-weight="bold" font-size="90" x="50" y="50" text-anchor="middle" dominant-baseline="central">i</text>
-        </svg>
-      </a>
+      <a href="#" title="About Browserpad" id="about-icon">ⓘ</a>
     </span>
   </nav>
   <div id="about">

--- a/script.js
+++ b/script.js
@@ -79,3 +79,8 @@ document.onkeydown = function (e) {
         }
     }
 }
+
+// show the about dialog
+document.querySelector("#about-icon").onclick = function () {
+    document.querySelector("#about").showModal();
+};

--- a/style.css
+++ b/style.css
@@ -32,8 +32,11 @@ nav {
 #save a {
   text-decoration: none;
 }
-#about, #open > input {
+#open > input {
   display: none;
+}
+#about > form {
+  text-align: right;
 }
 #about-icon {
   text-decoration: none;

--- a/style.css
+++ b/style.css
@@ -35,7 +35,9 @@ nav {
 #about, #open > input {
   display: none;
 }
-svg {
-  vertical-align: middle;
+#about-icon {
+  text-decoration: none;
+  color: black;
+  font-weight: bold;
 }
 @media print { nav { display: none; } }


### PR DESCRIPTION
Regarding the issue #19, I tried to implement the Unicode "i" icon (U+2139) but it looked nothing like the images of it, the letter was loaded and backround was white, so I decided to give the SVG icon a go - it worked out better it seems! Of course, if you still want to try the Unicode way we can give it a shot, but I don't think it's right. Hope this fixes the issue!