### PR TITLE
README: fix Circle CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Circle](https://img.shields.io/circleci/project/github/browserpad/browserpad/gh-pages.svg?logo=circleci&label=Circle)](https://circleci.com/gh/browserpad/browserpad)
+[![Circle](https://img.shields.io/circleci/project/github/browserpad/browserpad/main.svg?logo=circleci&label=Circle+CI)](https://circleci.com/gh/browserpad/browserpad)
 
 # Browserpad
 


### PR DESCRIPTION
This is needed to reflect the recent renaming of the primary branch from "gh-pages" to "main".